### PR TITLE
fix mti table name calculation for Rails 6

### DIFF
--- a/lib/active_record/mti/connection_adapters/postgresql/schema_statements.rb
+++ b/lib/active_record/mti/connection_adapters/postgresql/schema_statements.rb
@@ -24,7 +24,7 @@ module ActiveRecord
               options[:options] = [%(INHERITS ("#{inherited_table}")), options[:options]].compact.join
             end
 
-            super(table_name, options) do |td|
+            super(table_name, **options) do |td|
               yield(td) if block_given?
 
               fix_inherits_statement(td) if inherited_table

--- a/lib/active_record/mti/core_extension.rb
+++ b/lib/active_record/mti/core_extension.rb
@@ -168,8 +168,7 @@ module ActiveRecord
             nil,
             23,
             false,
-            table_name,
-            nil
+            table_name
           )
 
           columns_hash["tableoid"] ||= column


### PR DESCRIPTION
Rails 6 has the concept of multiple database connections.  We need to use the superclass of the class exposed in AR to get MTI table calculations to work.